### PR TITLE
Have htmlproofer ignore canonical links

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,5 +7,5 @@
   <meta name="description" content="{{ site.description }}">
 
   <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
-  <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
+  <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}" data-proofer-ignore="true">
 </head>


### PR DESCRIPTION
The canonical links point to a URL that does not exist before the page
is created, which leads to false positives from htmlproofer. The
data-proofer-ignore attribute tells htmlproofer to ignore these links.
