### PR TITLE
New member page

### DIFF
--- a/_includes/about.html
+++ b/_includes/about.html
@@ -1,3 +1,5 @@
 <p>Code for Nashville is Nashville's new <a href="http://www.codeforamerica.org/">Code for America Brigade</a>. We are volunteers who collaborate with Metro government to promote <a href="https://en.wikipedia.org/wiki/Open_data">open data</a> and build <a href="https://en.wikipedia.org/wiki/Civic_application">civic apps</a>.</p>
 
 <p>We are a growing organization and need members with all types of skills. </p>The best way to become involved is to attend our next <a href="http://www.meetup.com/code-for-nashville/">hack night</a>. We meet monthly at the Sevier Park Community Center.</p>
+
+New To Code For Nashville? Visit our <a href="/new-members">New Members page</a>.

--- a/new_members.md
+++ b/new_members.md
@@ -1,0 +1,26 @@
+---
+layout: page
+permalink: /new-members/
+---
+#Steps to Become a Code For Nashville Member
+For those looking to become an active member of Code For Nashville there are a number of places where we discuss current and future projects, goals of the organization and everything in between. 
+
+##Where to Find us
+[Meetup](http://www.meetup.com/code-for-nashville/)
+This is where you can find dates for our monthly hack nights and leadership meetings. Each event is listed on meetup.com at least three weeks from the date. Here you can RSVP for an event, view what will be discussed each meeting and see who is attending.  
+
+[Google Groups](https://groups.google.com/forum/#!forum/code-for-nashville)
+Our google group is used primarily for non-project related communication including  interesting resources, extra meetings and general information regarding Code For Nashville.
+
+[GitHub](https://github.com/code-for-nashville)
+GitHub is our primary base for communication and for current and past projects. Here you will find a list of our projects including a basic overview of each project, its code and progress. We also have a tracker where problems not specific to a project can be discussed. Please email webmaster@codefornashville.org or ask at a hack night to be added to our GitHub organization. 
+
+[Google Drive](https://drive.google.com/open?id=0B0PAHI0CABpRaUNwUUVqZ1BmMGM&authuser=0)
+Google Drive is where we store documents like meeting notes, protocols, etc. We have a publicly viewable folder and a private one. To view the private one or get write access to either  [email us](webmaster@codefornashville.org) at webmaster@codefornashville.org or ask at a hack night.
+
+##Not A Techy?
+Awesome!  Code for Nashville is an organization, and organizations require people to… organize!  We can always use people to write/transcribe blog posts, help create organizational protocols, craft communication strategies, and reach out into the public domain.  Have a PR background?  Help us get people to use our apps!  If an app is fully developed and deployed, but there is no one to send it a request, does it make a sound?
+
+##I’ve just become a member of Code For Nashville, Now What?
+f you are interested in seeing what can be achieved through open government and technology join us for our next hack. We are always looking for new people to join Code For Nashville. No matter your skillset there is always something to contribute to. If you have any questions or queries regarding Code For Nashville or any of our projects please [email us](webmaster@codefornashville.org) at webmaster@codefornashville.org.
+


### PR DESCRIPTION
I have added a new member page and link to it on the homepage. Let me know if you thinkthe link should be in the menu instead. The page has the same information as the google docs document. 