### PR TITLE
pluralize emeriti

### DIFF
--- a/_includes/team.html
+++ b/_includes/team.html
@@ -23,7 +23,7 @@
 
     <details>
         <summary>
-            <h3 id="emeritus-header">Emeritus</h3>
+            <h3 id="emeritus-header">Emeriti</h3>
             <p>Past contributors to Code for Nashville</p>
         </summary>
         <div>


### PR DESCRIPTION
I wish there were a gender neutral plural - perhaps we should use "emeritae"